### PR TITLE
Remove ability to use a custom JWT subclass for parsing.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 0.6.0 - XXXX-XX-XX
 ==================
 
-  * Nothing yet...
+  * Remove ability to use a custom JWT parser class, it's not used and
+    adds needless complexity.
 
 0.5.0 - 2012-04-18
 ==================

--- a/browserid/jwt.py
+++ b/browserid/jwt.py
@@ -18,10 +18,8 @@ from browserid.utils import decode_bytes, encode_bytes
 from browserid.utils import decode_json_bytes, encode_json_bytes
 
 
-def parse(jwt, cls=None):
+def parse(jwt):
     """Parse a JWT from a string."""
-    if cls is None:
-        cls = JWT
     algorithm, payload, signature = jwt.split(".")
     signed_data = algorithm + "." + payload
     try:
@@ -30,7 +28,7 @@ def parse(jwt, cls=None):
         raise ValueError("badly formed JWT")
     payload = decode_json_bytes(payload)
     signature = decode_bytes(signature)
-    return cls(algorithm, payload, signature, signed_data)
+    return JWT(algorithm, payload, signature, signed_data)
 
 
 def generate(payload, key):

--- a/browserid/verifiers/local.py
+++ b/browserid/verifiers/local.py
@@ -26,7 +26,7 @@ class LocalVerifier(Verifier):
     """
 
     def __init__(self, audiences=None, trusted_secondaries=None, certs=None,
-                 parser_cls=None, warning=True):
+                 warning=True):
         if trusted_secondaries is None:
             trusted_secondaries = DEFAULT_TRUSTED_SECONDARIES
 
@@ -36,13 +36,12 @@ class LocalVerifier(Verifier):
         super(LocalVerifier, self).__init__(audiences)
         self.trusted_secondaries = trusted_secondaries
         self.certs = certs
-        self.parser_cls = parser_cls
 
         if warning:
             _emit_warning()
 
     def parse_jwt(self, data):
-        return jwt.parse(data, self.parser_cls)
+        return jwt.parse(data)
 
     def verify(self, assertion, audience=None, now=None):
         """Verify the given BrowserID assertion.

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ with open(os.path.join(here, 'CHANGES.txt')) as f:
 
 requires = ['M2Crypto', 'requests']
 
+tests_require = requires + ['mock']
+
 setup(name='PyBrowserID',
       version='0.5.0',
       description='Python library for the BrowserID Protocol',
@@ -29,5 +31,5 @@ setup(name='PyBrowserID',
       include_package_data=True,
       zip_safe=False,
       install_requires=requires,
-      tests_require=requires,
+      tests_require=tests_require,
       test_suite="browserid")


### PR DESCRIPTION
This functionality is not used and no longer planned to be used, removing it cleans up the API.
