### PR TITLE
mock is not supposed to be a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()
 
-requires = ['requests', 'mock']
+requires = ['requests']
 
 tests_require = requires + ['mock']
 


### PR DESCRIPTION
I don't think we need the dependency to mock when installing PyBrowserID, that's only useful for developers taht want to run the tests.
