### PR TITLE
Added Error Descriptions

### DIFF
--- a/browserid/errors.py
+++ b/browserid/errors.py
@@ -15,34 +15,34 @@ class Error(Exception):
 
 class ConnectionError(Error):
     """Error raised when PyBrowserID fails to connect to a remote server."""
-    pass
+    description = 'Failed to connect to remote server.'
 
 
 class TrustError(Error):
     """Base error class when assertions are well-formed but untrusted."""
-    pass
+    description = 'Untrusted assertion.'
 
 
 class InvalidSignatureError(TrustError):
     """Error raised when PyBrowserID encounters an invalid signature."""
-    pass
+    description = 'Signature is invalid.'
 
 
 class InvalidIssuerError(TrustError):
     """Error raised when a cert is from an invalid/untrusted issuer."""
-    pass
+    description = 'Certificate issued by invalid or untrusted issuer.'
 
 
 class ExpiredSignatureError(TrustError):
     """Error raised when PyBrowserID encounters an expired signature."""
-    pass
+    description = 'Signature is expired.'
 
 
 class AudienceMismatchError(TrustError):
     """Error raised when the audience does not match."""
-    pass
+    description = 'Audience does not match server.'
 
 
 class UnsupportedCertChainError(TrustError):
     """The spec for multi-cert chains is in flux; we don't support them yet."""
-    pass
+    description = 'Multiple-certificate chains not supported.'


### PR DESCRIPTION
I often find the **description** field on **HTTPException**s in the [Werkzeug](https://github.com/mitsuhiko/werkzeug) library very handy. These are simple error explanations, not phrased for the programmer as docstrings typically are, but rather for the end user. For that reason, one can just drop them into error pages, and end users get detailed explanations of their errors.

I found myself making a table of descriptions for the **Error** classes in [PyBrowserID](https://github.com/mozilla/PyBrowserID) for a project, but then I realized this sort of thing should be a pull request.

This also resolves some of the concerns expressed in #22.
