### PR TITLE
Remove tuple parameter unpacking for python3

### DIFF
--- a/browserid/crypto/_m2_monkeypatch.py
+++ b/browserid/crypto/_m2_monkeypatch.py
@@ -89,8 +89,9 @@ def dsa_set_priv(dsa, value):
 
 
 @maybe_provide(RSA)
-def new_key((e, n, d)):
+def new_key(parameters):
     """Create a RSA object from the given parameters."""
+    e, n, d = parameters
     rsa = m2.rsa_new()
     m2.rsa_set_e(rsa, e)
     m2.rsa_set_n(rsa, n)


### PR DESCRIPTION
When I install pybrowserid in python3 I get the following in my output:

```
....
byte-compiling build/bdist.linux-x86_64/egg/browserid/crypto/_m2_monkeypatch.py to _m2_monkeypatch.cpython-33.pyc
  File "build/bdist.linux-x86_64/egg/browserid/crypto/_m2_monkeypatch.py", line 92
    def new_key((e, n, d)):
                ^
SyntaxError: invalid syntax
....
```

Unpacking as shown above is no longer supported in python3; see [PEP3113](http://www.python.org/dev/peps/pep-3113/).
