### PR TITLE
Add support for extra IDP claims in the LocalVerifier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
     - "3.3"
     - "3.4"
+    - "3.5"
 install:
-    - pip install nose unittest2 mock --use-mirrors
-    - pip install . --use-mirrors
+    - pip install nose unittest2 mock
+    - pip install .
 script: nosetests -s browserid
 notifications:
     irc:

--- a/browserid/tests/test_verifiers.py
+++ b/browserid/tests/test_verifiers.py
@@ -153,6 +153,38 @@ class TestLocalVerifier(unittest.TestCase, VerifierTestCases):
         self.assertTrue(self.verifier.verify(assertion))
 
     @callwith(patched_supportdoc_fetching())
+    def test_extraction_of_extra_claims(self):
+        assertion = make_assertion("t@m.com", "http://e.com",
+            idp_claims={"extra": "claim"},
+            user_claims={"another": "claim"},
+        )
+        result = self.verifier.verify(assertion)
+        self.assertEqual(result["status"], "okay")
+        self.assertEqual(result["idpClaims"], {"extra": "claim"})
+        self.assertEqual(result["userClaims"], {"another": "claim"})
+
+    @callwith(patched_supportdoc_fetching())
+    def test_extraction_of_extra_claims_from_principal(self):
+        assertion = make_assertion("t@m.com", "http://e.com",
+            idp_claims={
+                "extra": "claim",
+                "principal": {
+                    "email": "t@m.com",
+                    "another": "claim",
+                    "public-key": "should-be-ignored",
+                }
+            },
+        )
+        result = self.verifier.verify(assertion)
+        self.assertEqual(result["status"], "okay")
+        self.assertEqual(result["idpClaims"], {
+            "extra": "claim",
+            "another": "claim",
+        })
+        self.assertTrue("userClaims" not in result)
+
+
+    @callwith(patched_supportdoc_fetching())
     def test_email_validation(self):
         verifier = LocalVerifier(warning=False, audiences="http://persona.org")
 
@@ -175,7 +207,6 @@ class TestLocalVerifier(unittest.TestCase, VerifierTestCases):
         assertion = make_assertion(u"test@example.com\u0000\n@evil.com",
                                    "http://persona.org")
         self.assertRaises(ValueError, verifier.verify, assertion)
-
 
     @callwith(patched_supportdoc_fetching())
     def test_audience_verification(self):

--- a/browserid/tests/test_verifiers.py
+++ b/browserid/tests/test_verifiers.py
@@ -126,6 +126,7 @@ class TestLocalVerifier(unittest.TestCase, VerifierTestCases):
         # There should be a warning about using this verifier.
         self.assertEquals(w[0].category, FutureWarning)
 
+    @callwith(patched_supportdoc_fetching())
     def test_error_handling_in_verify_certificate_chain(self):
         self.assertRaises(ValueError,
                           self.verifier.verify_certificate_chain, [])
@@ -236,6 +237,18 @@ class TestRemoteVerifier(unittest.TestCase, VerifierTestCases):
         requests.request.return_value = response
 
         return self.verifier.verify(assertion)
+
+    def test_expired_assertion(self):
+        try:
+            return super(TestRemoteVerifier, self).test_expired_assertion()
+        except ConnectionError:
+            raise unittest.SkipTest("error connecting to remote server")
+
+    def test_malformed_assertions(self):
+        try:
+            return super(TestRemoteVerifier, self).test_malformed_assertions()
+        except ConnectionError:
+            raise unittest.SkipTest("error connecting to remote server")
 
     def test_handling_of_valid_response_from_server(self):
         response_text = ('{"email": "t@m.com", "status": "okay", '


### PR DESCRIPTION
This is necessary when using the LocalVerifier class with PyFxA.